### PR TITLE
Gh 19

### DIFF
--- a/charts/depscloud/Chart.yaml
+++ b/charts/depscloud/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/depscloud/Chart.yaml
+++ b/charts/depscloud/Chart.yaml
@@ -31,17 +31,17 @@ dependencies:
     condition: postgres.enabled
   - name: extractor
     repository: file://../extractor
-    version: 0.1.11
+    version: 0.1.12
     condition: extractor.enabled
   - name: gateway
     repository: file://../gateway
-    version: 0.1.11
+    version: 0.1.12
     condition: gateway.enabled
   - name: indexer
     repository: file://../indexer
-    version: 0.1.12
+    version: 0.1.13
     condition: indexer.enabled
   - name: tracker
     repository: file://../tracker
-    version: 0.1.16
+    version: 0.1.17
     condition: tracker.enabled

--- a/charts/extractor/Chart.yaml
+++ b/charts/extractor/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/extractor/README.md
+++ b/charts/extractor/README.md
@@ -9,7 +9,7 @@ This chart bootstraps a Extractor deployment on a [Kubernetes](http://kubernetes
 
 ## Prerequisites
 
-- Kubernetes 1.15+
+- Kubernetes 1.16+
 - Helm 3.0+
 
 ## Installing the Chart

--- a/charts/extractor/templates/serviceaccount.yaml
+++ b/charts/extractor/templates/serviceaccount.yaml
@@ -5,6 +5,5 @@ metadata:
   name: {{ include "extractor.serviceAccountName" . }}
   labels:
     {{- include "extractor.labels" . | nindent 4 }}
-spec:
-  automountServiceAccountToken: false
+automountServiceAccountToken: false
 {{- end -}}

--- a/charts/extractor/templates/serviceaccount.yaml
+++ b/charts/extractor/templates/serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   name: {{ include "extractor.serviceAccountName" . }}
   labels:
     {{- include "extractor.labels" . | nindent 4 }}
+spec:
+  automountServiceAccountToken: false
 {{- end -}}

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -9,7 +9,7 @@ This chart bootstraps a Gateway deployment on a [Kubernetes](http://kubernetes.i
 
 ## Prerequisites
 
-- Kubernetes 1.15+
+- Kubernetes 1.16+
 - Helm 3.0+
 
 ## Installing the Chart

--- a/charts/gateway/templates/serviceaccount.yaml
+++ b/charts/gateway/templates/serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   name: {{ include "gateway.serviceAccountName" . }}
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
+spec:
+  automountServiceAccountToken: false
 {{- end -}}

--- a/charts/gateway/templates/serviceaccount.yaml
+++ b/charts/gateway/templates/serviceaccount.yaml
@@ -5,6 +5,5 @@ metadata:
   name: {{ include "gateway.serviceAccountName" . }}
   labels:
     {{- include "gateway.labels" . | nindent 4 }}
-spec:
-  automountServiceAccountToken: false
+automountServiceAccountToken: false
 {{- end -}}

--- a/charts/indexer/Chart.yaml
+++ b/charts/indexer/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.12
+version: 0.1.13
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/indexer/README.md
+++ b/charts/indexer/README.md
@@ -9,7 +9,7 @@ This chart bootstraps an Indexer cron on a [Kubernetes](http://kubernetes.io) cl
 
 ## Prerequisites
 
-- Kubernetes 1.15+
+- Kubernetes 1.16+
 - Helm 3.0+
 
 ## Installing the Chart

--- a/charts/indexer/templates/serviceaccount.yaml
+++ b/charts/indexer/templates/serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   name: {{ include "indexer.serviceAccountName" . }}
   labels:
     {{- include "indexer.labels" . | nindent 4 }}
+spec:
+  automountServiceAccountToken: false
 {{- end -}}

--- a/charts/indexer/templates/serviceaccount.yaml
+++ b/charts/indexer/templates/serviceaccount.yaml
@@ -5,6 +5,5 @@ metadata:
   name: {{ include "indexer.serviceAccountName" . }}
   labels:
     {{- include "indexer.labels" . | nindent 4 }}
-spec:
-  automountServiceAccountToken: false
+automountServiceAccountToken: false
 {{- end -}}

--- a/charts/tracker/Chart.yaml
+++ b/charts/tracker/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.16
+version: 0.1.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/tracker/README.md
+++ b/charts/tracker/README.md
@@ -9,7 +9,7 @@ This chart bootstraps a Tracker deployment on a [Kubernetes](http://kubernetes.i
 
 ## Prerequisites
 
-- Kubernetes 1.15+
+- Kubernetes 1.16+
 - Helm 3.0+
 
 ## Installing the Chart

--- a/charts/tracker/templates/serviceaccount.yaml
+++ b/charts/tracker/templates/serviceaccount.yaml
@@ -5,6 +5,5 @@ metadata:
   name: {{ include "tracker.serviceAccountName" . }}
   labels:
     {{- include "tracker.labels" . | nindent 4 }}
-spec:
-  automountServiceAccountToken: false
+automountServiceAccountToken: false
 {{- end -}}

--- a/charts/tracker/templates/serviceaccount.yaml
+++ b/charts/tracker/templates/serviceaccount.yaml
@@ -5,4 +5,6 @@ metadata:
   name: {{ include "tracker.serviceAccountName" . }}
   labels:
     {{- include "tracker.labels" . | nindent 4 }}
+spec:
+  automountServiceAccountToken: false
 {{- end -}}


### PR DESCRIPTION
Resolves gh-19
# Notes
With this change we now require k8 1.16+

# Verified using helm

~/i/d/d/c/tracker ❯❯❯ helm install -f Chart.yaml my-tracker ./                                                                                                      ✘ 1 gh-19 ✱
NAME: my-tracker
LAST DEPLOYED: Wed Aug  5 16:34:14 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
~/i/d/d/c/tracker ❯❯❯ cd ../extractor                                                                                                                                   gh-19 ✱
~/i/d/d/c/extractor ❯❯❯ helm install -f Chart.yaml my-extractor ./                                                                                                      gh-19 ✱
NAME: my-extractor
LAST DEPLOYED: Wed Aug  5 16:35:11 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
~/i/d/d/c/extractor ❯❯❯ cd ../gateway                                                                                                                                   gh-19 ✱
~/i/d/d/c/gateway ❯❯❯ helm install -f Chart.yaml my-gateway ./                                                                                                          gh-19 ✱
NAME: my-gateway
LAST DEPLOYED: Wed Aug  5 16:35:23 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
~/i/d/d/c/gateway ❯❯❯ cd ../indexer                                                                                                                                     gh-19 ✱
~/i/d/d/c/indexer ❯❯❯ helm install -f Chart.yaml my-indexer ./                                                                                                          gh-19 ✱
NAME: my-indexer
LAST DEPLOYED: Wed Aug  5 16:35:37 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None